### PR TITLE
drop isPlatformWayland() == true code pathes

### DIFF
--- a/applets/pager/pagermodel.cpp
+++ b/applets/pager/pagermodel.cpp
@@ -351,7 +351,7 @@ int PagerModel::layoutRows() const
 QSize PagerModel::pagerItemSize() const
 {
     if (d->showOnlyCurrentScreen && d->screenGeometry.isValid()) {
-        const double devicePixelRatio = KWindowSystem::isPlatformWayland() ? 1.0 : qGuiApp->devicePixelRatio();
+        const double devicePixelRatio = qGuiApp->devicePixelRatio();
         return d->screenGeometry.size() * devicePixelRatio;
     }
 
@@ -524,8 +524,6 @@ void PagerModel::drop(QMimeData *mimeData, int modifiers, const QVariant &itemId
     QList<QModelIndex> indices;
     if (KWindowSystem::isPlatformX11()) {
         indices = findWindows(TaskManager::XWindowTasksModel::winIdsFromMimeData(mimeData, &ok));
-    } else if (KWindowSystem::isPlatformWayland()) {
-        indices = findWindows(TaskManager::WaylandTasksModel::winIdsFromMimeData(mimeData, &ok));
     }
     if (!ok) {
         return;
@@ -591,7 +589,7 @@ void PagerModel::componentComplete()
 
 void PagerModel::computePagerItemSize()
 {
-    const double devicePixelRatio = KWindowSystem::isPlatformWayland() ? 1.0 : qGuiApp->devicePixelRatio();
+    const double devicePixelRatio = qGuiApp->devicePixelRatio();
     QRect wholeScreen;
     for (const auto screens = qGuiApp->screens(); auto screen : screens) {
         const QRect geometry = screen->geometry();

--- a/applets/taskmanager/qml/ToolTipInstance.qml
+++ b/applets/taskmanager/qml/ToolTipInstance.qml
@@ -305,7 +305,7 @@ ColumnLayout {
             active: Plasmoid.configuration.showToolTips
                 && !toolTipDelegate.isLauncher
                 && !albumArtImage.visible
-                && KWindowSystem.isPlatformWayland
+                && false
                 && root.index !== -1
             asynchronous: true
             //In a loader since we might not have PipeWire available yet (WITH_PIPEWIRE could be undefined in plasma-workspace/libtaskmanager/declarative/taskmanagerplugin.cpp)

--- a/desktoppackage/contents/views/Panel.qml
+++ b/desktoppackage/contents/views/Panel.qml
@@ -219,7 +219,7 @@ Item {
             floatingnessTarget = 1
             floatingApplets = true
         }
-        if (!KWindowSystem.isPlatformWayland && !KX11Extras.compositingActive) {
+        if (!KX11Extras.compositingActive) {
             opaqueApplets = false
             panelOpacity = 0
         }

--- a/imports/activitymanager/switcherbackend.cpp
+++ b/imports/activitymanager/switcherbackend.cpp
@@ -440,9 +440,6 @@ bool SwitcherBackend::dragContainsWindows(QMimeData *mimeData) const
     if (KWindowSystem::isPlatformX11()) {
         return TaskManager::XWindowTasksModel::winIdsFromMimeData(mimeData).count();
     }
-    if (KWindowSystem::isPlatformWayland()) {
-        return TaskManager::WaylandTasksModel::winIdsFromMimeData(mimeData).count();
-    }
     return false;
 }
 

--- a/kcms/access/ui/main.qml
+++ b/kcms/access/ui/main.qml
@@ -72,7 +72,7 @@ KCMUtils.AbstractKCM {
             icon: "cursor-arrow",
             title: i18nc("@title Category name in sidebar, shake pointer to find it", "Shake Pointer"),
             defaultnessKey: "shakeCursorIsDefaults",
-            available: KWindowSystem.isPlatformWayland
+            available: false
         }
     ]
 

--- a/kcms/workspaceoptions/ui/main.qml
+++ b/kcms/workspaceoptions/ui/main.qml
@@ -244,7 +244,7 @@ KCM.SimpleKCM {
         QQC2.CheckBox {
             id: primarySelectionRadio
             Kirigami.FormData.label: i18nc("@label for checkbox, part of a complete sentence: 'Middle-click pastes selected text'", "Middle-click:")
-            visible: KWindowSystem.isPlatformWayland
+            visible: false
             text: i18nc("@option:check part of a complete sentence: 'Middle click pastes selected text'", "Pastes selected text")
             checked: kcm.kwinSettings.primarySelection
             onToggled: kcm.kwinSettings.primarySelection = checked
@@ -415,7 +415,7 @@ KCM.SimpleKCM {
         RowLayout {
             Kirigami.FormData.label: i18nc("@title:group prefix radiobutton group", "Enable Touch Mode:")
             QQC2.RadioButton {
-                text: KWindowSystem.isPlatformWayland ? i18nc("@option:radio As in: 'Touch Mode is automatically enabled as needed'", "Automatically enable as needed") : i18nc("option:radio As in: 'Touch Mode is never enabled'", "Never enabled")
+                text: false ? i18nc("@option:radio As in: 'Touch Mode is automatically enabled as needed'", "Automatically enable as needed") : i18nc("option:radio As in: 'Touch Mode is never enabled'", "Never enabled")
                 Accessible.description: touchModeAlwaysOffRadioButtonHelperText.text
                 checked: kcm.kwinSettings.tabletMode === "auto"
                 onToggled: {
@@ -431,7 +431,7 @@ KCM.SimpleKCM {
                 }
             }
             Kirigami.ContextualHelpButton {
-                visible: KWindowSystem.isPlatformWayland
+                visible: false
                 toolTipText: i18nc("@info:whatsthis contextualhelpbutton tooltip", "Touch Mode will be automatically activated whenever the system detects a touchscreen but no mouse or touchpad. For example: when a transformable laptop's keyboard is flipped around or detached.")
             }
         }
@@ -459,7 +459,7 @@ KCM.SimpleKCM {
 
             QQC2.RadioButton {
                 id: touchModeAlwaysOffRadioButton
-                visible: KWindowSystem.isPlatformWayland
+                visible: false
                 text: i18nc("As in: 'Touch Mode is never enabled'", "Disabled")
                 Accessible.description: touchModeAlwaysOffRadioButtonHelperText.text
                 checked: kcm.kwinSettings.tabletMode === "off"


### PR DESCRIPTION
Drop code pathes that are only active when running under Wayland.